### PR TITLE
Align CSRF header contract and seed demo user in Flyway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# macOS / OS
+.DS_Store
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# Node
+node_modules/
+frontend/node_modules/
+frontend/dist/
+frontend/.vite/
+frontend/npm-debug.log*
+
+# Java / Maven
+backend/target/
+*.class
+
+# Env
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,149 @@
-# New Project
+# corck-board monorepo (single artifact stack)
 
-Repository reset and ready for a new project.
+A full-stack monorepo with:
+- `frontend/`: Vue 3 + Vite + TypeScript SPA
+- `backend/`: Spring Boot 3 (Java 17, Maven) API + static asset hosting
+- `docker-compose.yml`: local Postgres
+
+In production, Spring Boot serves both API and built SPA from one deployable JAR.
+
+## Repository structure
+
+```text
+my-repo/
+  frontend/
+  backend/
+  docker-compose.yml
+  README.md
+  .gitignore
+```
+
+## Prerequisites
+
+- Java 17
+- Maven 3.9+
+- Docker + Docker Compose
+- Node is only required for standalone frontend dev (`npm install && npm run dev`)
+  - For production build, Maven installs/pins Node and npm via `frontend-maven-plugin`.
+
+## Start Postgres
+
+```bash
+docker compose up -d
+```
+
+Default DB settings:
+- database: `corckboard`
+- username: `corckboard`
+- password: `corckboard`
+- host/port: `localhost:5432`
+
+## Development mode
+
+Run backend and frontend separately.
+
+### Backend
+
+```bash
+cd backend
+mvn spring-boot:run
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Vite proxies `/api` to `http://localhost:8080`, so no CORS config is needed in dev.
+
+## Production / single-artifact run
+
+Build and run only the backend JAR. During package:
+- Maven installs Node/npm (pinned)
+- runs `npm ci` + `npm run build` in `frontend/`
+- copies `frontend/dist` into backend static resources
+
+```bash
+cd backend
+mvn clean package
+java -jar target/*.jar
+```
+
+Open: `http://localhost:8080`
+
+### Skip frontend build when needed
+
+```bash
+mvn clean package -DskipFrontend=true
+```
+
+## Authentication behavior
+
+- Cookie-based session auth (Spring Security session + `JSESSIONID` HttpOnly cookie)
+- No JWT/localStorage tokens
+- Demo user is seeded by Flyway migration:
+  - username: `demo`
+  - password: `demo123`
+
+### CSRF
+
+CSRF is enabled for cookie-session safety with `CookieCsrfTokenRepository`.
+Frontend first calls `GET /api/v1/csrf`, then sends `X-CSRF-TOKEN` header on state-changing requests.
+
+## API endpoints
+
+- Public:
+  - `GET /api/v1/health`
+  - `GET /api/v1/csrf`
+  - `POST /api/v1/auth/login`
+  - `POST /api/v1/auth/logout`
+- Auth required:
+  - `GET /api/v1/auth/me`
+  - `GET /api/v1/hello`
+  - `GET /api/v1/notes`
+  - `POST /api/v1/notes`
+
+## Example curl flow
+
+```bash
+# 1) Fetch CSRF token + cookie
+curl -i -c cookies.txt http://localhost:8080/api/v1/csrf
+
+# 2) Login (replace TOKEN from previous response JSON)
+curl -i -b cookies.txt -c cookies.txt \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-TOKEN: TOKEN" \
+  -d '{"username":"demo","password":"demo123"}' \
+  http://localhost:8080/api/v1/auth/login
+
+# 3) Current user
+curl -i -b cookies.txt http://localhost:8080/api/v1/auth/me
+
+# 4) Create note (include latest CSRF token)
+curl -i -b cookies.txt \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-TOKEN: TOKEN" \
+  -d '{"title":"First note","body":"Created from curl"}' \
+  http://localhost:8080/api/v1/notes
+```
+
+## Troubleshooting
+
+- **Cannot connect to DB**:
+  - Ensure `docker compose up -d` is running.
+  - Verify backend env vars if using non-default DB values:
+    - `DB_URL`
+    - `DB_USERNAME`
+    - `DB_PASSWORD`
+- **Flyway migration issues**:
+  - Check `backend/src/main/resources/db/migration` scripts.
+  - Reset local DB volume if schema is out of sync:
+    ```bash
+    docker compose down -v
+    docker compose up -d
+    ```
+- **Frontend not embedded in jar**:
+  - Ensure `mvn clean package` ran without `-DskipFrontend=true`.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,148 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.2</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.home.app</groupId>
+    <artifactId>corck-board</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>corck-board</name>
+    <description>Single artifact Vue + Spring Boot app</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <node.version>v20.17.0</node.version>
+        <npm.version>10.8.2</npm.version>
+        <skipFrontend>false</skipFrontend>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.15.0</version>
+                <configuration>
+                    <workingDirectory>../frontend</workingDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>${node.version}</nodeVersion>
+                            <npmVersion>${npm.version}</npmVersion>
+                            <skip>${skipFrontend}</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm ci</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                            <skip>${skipFrontend}</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm build</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run build</arguments>
+                            <skip>${skipFrontend}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-frontend-dist</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <skip>${skipFrontend}</skip>
+                            <outputDirectory>${project.build.outputDirectory}/static</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../frontend/dist</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/io/home/app/corckboard/CorckBoardApplication.java
+++ b/backend/src/main/java/io/home/app/corckboard/CorckBoardApplication.java
@@ -1,0 +1,12 @@
+package io.home.app.corckboard;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CorckBoardApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CorckBoardApplication.class, args);
+    }
+}

--- a/backend/src/main/java/io/home/app/corckboard/auth/AppUserDetailsService.java
+++ b/backend/src/main/java/io/home/app/corckboard/auth/AppUserDetailsService.java
@@ -1,0 +1,28 @@
+package io.home.app.corckboard.auth;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AppUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public AppUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserEntity user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return User.withUsername(user.getUsername())
+            .password(user.getPasswordHash())
+            .disabled(!user.isEnabled())
+            .authorities("USER")
+            .build();
+    }
+}

--- a/backend/src/main/java/io/home/app/corckboard/auth/AuthController.java
+++ b/backend/src/main/java/io/home/app/corckboard/auth/AuthController.java
@@ -1,0 +1,74 @@
+package io.home.app.corckboard.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthenticationManager authenticationManager;
+
+    public AuthController(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request,
+                                   HttpServletRequest httpRequest,
+                                   HttpServletResponse httpResponse) {
+        try {
+            Authentication auth = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.username(), request.password())
+            );
+
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+
+            HttpSession session = httpRequest.getSession(true);
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+
+            return ResponseEntity.ok(Map.of("username", auth.getName()));
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Invalid credentials"));
+        }
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Map<String, String>> logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.ok(Map.of("status", "logged out"));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> me(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getName())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Unauthorized"));
+        }
+        return ResponseEntity.ok(Map.of("username", authentication.getName()));
+    }
+
+    public record LoginRequest(@NotBlank String username, @NotBlank String password) {}
+}

--- a/backend/src/main/java/io/home/app/corckboard/auth/CsrfController.java
+++ b/backend/src/main/java/io/home/app/corckboard/auth/CsrfController.java
@@ -1,0 +1,17 @@
+package io.home.app.corckboard.auth;
+
+import java.util.Map;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class CsrfController {
+
+    @GetMapping("/csrf")
+    public Map<String, String> csrf(CsrfToken token) {
+        return Map.of("token", token.getToken());
+    }
+}

--- a/backend/src/main/java/io/home/app/corckboard/auth/UserEntity.java
+++ b/backend/src/main/java/io/home/app/corckboard/auth/UserEntity.java
@@ -1,0 +1,34 @@
+package io.home.app.corckboard.auth;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    public Long getId() { return id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/io/home/app/corckboard/auth/UserRepository.java
+++ b/backend/src/main/java/io/home/app/corckboard/auth/UserRepository.java
@@ -1,0 +1,8 @@
+package io.home.app.corckboard.auth;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUsername(String username);
+}

--- a/backend/src/main/java/io/home/app/corckboard/common/ApiController.java
+++ b/backend/src/main/java/io/home/app/corckboard/common/ApiController.java
@@ -1,0 +1,21 @@
+package io.home.app.corckboard.common;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ApiController {
+
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of("status", "ok");
+    }
+
+    @GetMapping("/hello")
+    public Map<String, String> hello() {
+        return Map.of("message", "Hello from Spring Boot");
+    }
+}

--- a/backend/src/main/java/io/home/app/corckboard/common/SpaForwardingController.java
+++ b/backend/src/main/java/io/home/app/corckboard/common/SpaForwardingController.java
@@ -1,0 +1,13 @@
+package io.home.app.corckboard.common;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class SpaForwardingController {
+
+    @RequestMapping(value = {"/{path:^(?!api$).*$}", "/{path:^(?!api$).*$}/**/{subpath:[^\\.]*}"})
+    public String forward() {
+        return "forward:/index.html";
+    }
+}

--- a/backend/src/main/java/io/home/app/corckboard/config/SecurityConfig.java
+++ b/backend/src/main/java/io/home/app/corckboard/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package io.home.app.corckboard.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> {
+                CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+                csrfTokenRepository.setHeaderName("X-CSRF-TOKEN");
+                csrf.csrfTokenRepository(csrfTokenRepository);
+            })
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/", "/index.html", "/favicon.ico", "/assets/**",
+                    "/*.js", "/*.css", "/*.ico"
+                ).permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/health", "/api/v1/csrf").permitAll()
+                .requestMatchers("/api/v1/auth/login", "/api/v1/auth/logout").permitAll()
+                .requestMatchers("/api/v1/**").authenticated()
+                .anyRequest().permitAll()
+            )
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+            .formLogin(form -> form.disable())
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((req, res, ex2) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/io/home/app/corckboard/notes/NoteEntity.java
+++ b/backend/src/main/java/io/home/app/corckboard/notes/NoteEntity.java
@@ -1,0 +1,41 @@
+package io.home.app.corckboard.notes;
+
+import io.home.app.corckboard.auth.UserEntity;
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "notes")
+public class NoteEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public Long getId() { return id; }
+    public UserEntity getUser() { return user; }
+    public void setUser(UserEntity user) { this.user = user; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getBody() { return body; }
+    public void setBody(String body) { this.body = body; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public OffsetDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/io/home/app/corckboard/notes/NoteRepository.java
+++ b/backend/src/main/java/io/home/app/corckboard/notes/NoteRepository.java
@@ -1,0 +1,9 @@
+package io.home.app.corckboard.notes;
+
+import io.home.app.corckboard.auth.UserEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<NoteEntity, Long> {
+    List<NoteEntity> findByUserOrderByCreatedAtDesc(UserEntity user);
+}

--- a/backend/src/main/java/io/home/app/corckboard/notes/NotesController.java
+++ b/backend/src/main/java/io/home/app/corckboard/notes/NotesController.java
@@ -1,0 +1,62 @@
+package io.home.app.corckboard.notes;
+
+import io.home.app.corckboard.auth.UserEntity;
+import io.home.app.corckboard.auth.UserRepository;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notes")
+public class NotesController {
+    private final NoteRepository noteRepository;
+    private final UserRepository userRepository;
+
+    public NotesController(NoteRepository noteRepository, UserRepository userRepository) {
+        this.noteRepository = noteRepository;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping
+    public List<NoteResponse> list(Authentication authentication) {
+        UserEntity user = currentUser(authentication);
+        return noteRepository.findByUserOrderByCreatedAtDesc(user).stream()
+            .map(note -> new NoteResponse(note.getId(), note.getTitle(), note.getBody(), note.getCreatedAt(), note.getUpdatedAt()))
+            .toList();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public NoteResponse create(Authentication authentication, @Valid @RequestBody CreateNoteRequest request) {
+        UserEntity user = currentUser(authentication);
+        OffsetDateTime now = OffsetDateTime.now();
+
+        NoteEntity note = new NoteEntity();
+        note.setUser(user);
+        note.setTitle(request.title());
+        note.setBody(request.body());
+        note.setCreatedAt(now);
+        note.setUpdatedAt(now);
+
+        NoteEntity saved = noteRepository.save(note);
+        return new NoteResponse(saved.getId(), saved.getTitle(), saved.getBody(), saved.getCreatedAt(), saved.getUpdatedAt());
+    }
+
+    private UserEntity currentUser(Authentication authentication) {
+        return userRepository.findByUsername(authentication.getName())
+            .orElseThrow(() -> new IllegalStateException("Authenticated user not found"));
+    }
+
+    public record CreateNoteRequest(@NotBlank String title, @NotBlank String body) {}
+
+    public record NoteResponse(Long id, String title, String body, OffsetDateTime createdAt, OffsetDateTime updatedAt) {}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/corckboard}
+    username: ${DB_USERNAME:corckboard}
+    password: ${DB_PASSWORD:corckboard}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  flyway:
+    enabled: true
+server:
+  port: ${SERVER_PORT:8080}

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,23 @@
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE notes (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_notes_user_id ON notes(user_id);
+
+-- demo / demo123 (BCrypt)
+INSERT INTO users (username, password_hash, enabled)
+VALUES ('demo', '$2y$12$UI1/4VUHeuvqlqrLESkCy.wfP4dgHIx5REO5P/ETSYTrliWOCno4q', TRUE)
+ON CONFLICT (username) DO NOTHING;

--- a/backend/src/test/java/io/home/app/corckboard/ApiSecurityIntegrationTest.java
+++ b/backend/src/test/java/io/home/app/corckboard/ApiSecurityIntegrationTest.java
@@ -1,0 +1,37 @@
+package io.home.app.corckboard;
+
+import io.home.app.corckboard.auth.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration"
+})
+@AutoConfigureMockMvc
+class ApiSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void healthEndpointShouldReturn200() throws Exception {
+        mockMvc.perform(get("/api/v1/health"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void helloShouldReturn401WhenNotLoggedIn() throws Exception {
+        mockMvc.perform(get("/api/v1/hello"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: corckboard-postgres
+    environment:
+      POSTGRES_DB: corckboard
+      POSTGRES_USER: corckboard
+      POSTGRES_PASSWORD: corckboard
+    ports:
+      - "5432:5432"
+    volumes:
+      - corckboard-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  corckboard-postgres-data:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Corck Board</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "pinia": "^2.1.7",
+    "vue": "^3.4.38",
+    "vue-router": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "@vitejs/plugin-vue": "^5.1.2",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2",
+    "vue-tsc": "^2.0.29"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="app-shell">
+    <header>
+      <h1>Corck Board</h1>
+      <nav>
+        <RouterLink to="/">Home</RouterLink>
+        <RouterLink to="/about">About</RouterLink>
+        <RouterLink to="/login">Login</RouterLink>
+      </nav>
+    </header>
+    <main>
+      <RouterView />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.app-shell {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 1rem;
+}
+nav {
+  display: flex;
+  gap: 1rem;
+}
+main {
+  padding: 1rem 0;
+}
+</style>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,44 @@
+const CSRF_HEADER = 'X-CSRF-TOKEN'
+
+export type ApiError = { error?: string }
+
+let csrfToken: string | null = null
+
+async function ensureCsrfToken(): Promise<string> {
+  if (csrfToken) return csrfToken
+
+  const response = await fetch('/api/v1/csrf', {
+    method: 'GET',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error('Unable to obtain CSRF token')
+  }
+
+  const data = (await response.json()) as { token: string }
+  csrfToken = data.token
+  return csrfToken
+}
+
+export async function apiRequest<T>(url: string, init: RequestInit = {}, needsCsrf = false): Promise<T> {
+  const headers = new Headers(init.headers ?? {})
+  headers.set('Content-Type', 'application/json')
+
+  if (needsCsrf) {
+    headers.set(CSRF_HEADER, await ensureCsrfToken())
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    headers,
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    const message = (await response.json().catch(() => ({}))) as ApiError
+    throw new Error(message.error ?? `Request failed (${response.status})`)
+  }
+
+  return (await response.json()) as T
+}

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import router from './router'
+
+createApp(App).use(createPinia()).use(router).mount('#app')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,33 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+import LoginView from '../views/LoginView.vue'
+import AboutView from '../views/AboutView.vue'
+import { useAuthStore } from '../stores/auth'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', name: 'home', component: HomeView, meta: { requiresAuth: true } },
+    { path: '/login', name: 'login', component: LoginView },
+    { path: '/about', name: 'about', component: AboutView, meta: { requiresAuth: true } },
+  ],
+})
+
+router.beforeEach(async (to) => {
+  const authStore = useAuthStore()
+  if (!authStore.user) {
+    await authStore.fetchMe()
+  }
+
+  if (to.meta.requiresAuth && !authStore.user) {
+    return { name: 'login' }
+  }
+
+  if (to.name === 'login' && authStore.user) {
+    return { name: 'home' }
+  }
+
+  return true
+})
+
+export default router

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia'
+import { apiRequest } from '../api'
+
+export type AuthUser = { username: string }
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    user: null as AuthUser | null,
+    loading: false,
+    error: '' as string,
+  }),
+  actions: {
+    async fetchMe() {
+      this.loading = true
+      try {
+        this.user = await apiRequest<AuthUser>('/api/v1/auth/me')
+      } catch {
+        this.user = null
+      } finally {
+        this.loading = false
+      }
+    },
+    async login(username: string, password: string) {
+      this.loading = true
+      this.error = ''
+      try {
+        this.user = await apiRequest<AuthUser>(
+          '/api/v1/auth/login',
+          {
+            method: 'POST',
+            body: JSON.stringify({ username, password }),
+          },
+          true,
+        )
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : 'Login failed'
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+    async logout() {
+      await apiRequest<{ status: string }>(
+        '/api/v1/auth/logout',
+        {
+          method: 'POST',
+        },
+        true,
+      )
+      this.user = null
+    },
+  },
+})

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -1,0 +1,6 @@
+<template>
+  <section>
+    <h2>About</h2>
+    <p>This route is protected to show session-based auth with Vue Router guards.</p>
+  </section>
+</template>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { apiRequest } from '../api'
+import { useAuthStore } from '../stores/auth'
+
+type HelloPayload = { message: string }
+type Note = {
+  id: number
+  title: string
+  body: string
+  createdAt: string
+  updatedAt: string
+}
+
+const authStore = useAuthStore()
+const helloMessage = ref('')
+const notes = ref<Note[]>([])
+const title = ref('')
+const body = ref('')
+const error = ref('')
+
+const loadData = async () => {
+  try {
+    const hello = await apiRequest<HelloPayload>('/api/v1/hello')
+    helloMessage.value = hello.message
+    notes.value = await apiRequest<Note[]>('/api/v1/notes')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed loading data'
+  }
+}
+
+const createNote = async () => {
+  await apiRequest<Note>(
+    '/api/v1/notes',
+    {
+      method: 'POST',
+      body: JSON.stringify({ title: title.value, body: body.value }),
+    },
+    true,
+  )
+  title.value = ''
+  body.value = ''
+  await loadData()
+}
+
+const logout = async () => {
+  await authStore.logout()
+  window.location.href = '/login'
+}
+
+onMounted(loadData)
+</script>
+
+<template>
+  <section>
+    <h2>Home</h2>
+    <p><strong>User:</strong> {{ authStore.user?.username }}</p>
+    <p><strong>Backend says:</strong> {{ helloMessage }}</p>
+    <button @click="logout">Logout</button>
+
+    <h3>Create note</h3>
+    <form @submit.prevent="createNote">
+      <label>
+        Title
+        <input v-model="title" required />
+      </label>
+      <label>
+        Body
+        <textarea v-model="body" required />
+      </label>
+      <button type="submit">Create</button>
+    </form>
+
+    <p v-if="error" class="error">{{ error }}</p>
+
+    <h3>Your notes</h3>
+    <ul>
+      <li v-for="note in notes" :key="note.id">
+        <strong>{{ note.title }}</strong>
+        <p>{{ note.body }}</p>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+form {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 420px;
+  margin-bottom: 1rem;
+}
+label {
+  display: grid;
+  gap: 0.25rem;
+}
+.error {
+  color: #b00020;
+}
+ul {
+  padding-left: 1rem;
+}
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+
+const authStore = useAuthStore()
+const router = useRouter()
+
+const username = ref('demo')
+const password = ref('demo123')
+
+const submit = async () => {
+  try {
+    await authStore.login(username.value, password.value)
+    await router.push('/')
+  } catch {
+    // no-op (error already set on store)
+  }
+}
+</script>
+
+<template>
+  <section>
+    <h2>Login</h2>
+    <p>Use <strong>demo/demo123</strong>.</p>
+    <form @submit.prevent="submit">
+      <label>
+        Username
+        <input v-model="username" required />
+      </label>
+      <label>
+        Password
+        <input v-model="password" type="password" required />
+      </label>
+      <button :disabled="authStore.loading" type="submit">Sign in</button>
+    </form>
+    <p v-if="authStore.error" class="error">{{ authStore.error }}</p>
+  </section>
+</template>
+
+<style scoped>
+form {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 320px;
+}
+label {
+  display: grid;
+  gap: 0.25rem;
+}
+.error {
+  color: #b00020;
+}
+</style>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Motivation
- Provide a complete single-artifact monorepo where the Spring Boot backend serves the built Vue SPA and API from the same origin and uses cookie-based session auth. 
- Make demo credentials deterministic by seeding the demo user at migration time instead of relying on runtime initialization. 
- Unify the CSRF header contract between server, client, and docs and remove unused HTTP Basic from the security chain for a clearer security surface.

### Description
- Backend: added a Spring Boot 3 app (Java 17, Maven) with session-based auth, JSON auth endpoints (`POST /api/v1/auth/login`, `POST /api/v1/auth/logout`, `GET /api/v1/auth/me`), a CSRF endpoint (`GET /api/v1/csrf`), protected API routes under `/api/v1/**`, notes CRUD endpoints, and SPA forwarding controller to serve `index.html` for non-asset/non-API routes. 
- Security: updated `SecurityConfig` to use `CookieCsrfTokenRepository` with header name `X-CSRF-TOKEN`, disabled form login and HTTP Basic, and registered a `BCryptPasswordEncoder` and `AuthenticationManager`. 
- Database & migrations: added `backend/src/main/resources/db/migration/V1__init_schema.sql` to create `users` and `notes` tables and to seed the `demo` user with a BCrypt hash, and removed the runtime `DefaultUserInitializer`. 
- Frontend: added a Vue 3 + Vite + TypeScript SPA with Pinia auth store, Vue Router (history mode) with routes `/`, `/login`, `/about`, an `api.ts` client that uses `credentials: 'include'` and sends `X-CSRF-TOKEN` for state-changing requests, and a minimal Home/Login UI demonstrating the hello and notes flows. 
- Build & infra: added `frontend-maven-plugin` configuration to build the frontend during `mvn package`, resource copy into the jar, `docker-compose.yml` for local Postgres, a `.gitignore`, and updated `README.md` with dev/prod instructions and matching curl examples.

### Testing
- Attempted to run backend tests with `cd backend && mvn -q test -DskipFrontend=true`, but the run failed due to environment network restrictions preventing Maven Central access (failure: Spring Boot parent POM could not be fetched, HTTP 403). 
- Attempted frontend build with `cd frontend && npm run build`, but the build failed in this environment because dev dependencies are not installed (`vue-tsc: not found`). 
- Included Spring Boot tests in the repository for `GET /api/v1/health` (expects 200) and a security test verifying `GET /api/v1/hello` returns 401 when unauthenticated, but these tests could not be executed successfully here due to the environment restrictions above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69958a158c84832f951f491bdf8a9a03)